### PR TITLE
Fix miner coal collection and correct registration of ai filter

### DIFF
--- a/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
@@ -7,6 +7,7 @@ import com.leviathanstudio.craftstudio.client.util.EnumResourceType;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCrops;
 import net.minecraft.block.BlockOre;
+import net.minecraft.init.Items;
 import net.minecraft.item.*;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Loader;
@@ -192,6 +193,8 @@ public class TektopiaAddons {
 		LOGGER.info("Found " + gemItems.size() + " gems");
 		LOGGER.info("Found " + ingotItems.size() + " ingots");
 
+
+		OreDictionary.registerOre("coal", Items.COAL);
 
 		Collection<Block> blocks = ForgeRegistries.BLOCKS.getValuesCollection();
 		for(Block block : blocks)

--- a/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityMinerMixin.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityMinerMixin.java
@@ -49,19 +49,20 @@ public abstract class EntityMinerMixin extends EntityVillagerTek {
     @Overwrite(remap = false)
     //Update the isHarvestItem method to pickup oredictionary ores, gems and dusts
     public Predicate<ItemStack> isHarvestItem() {
-        return (p) -> Arrays.stream(OreDictionary.getOreIDs(p)).anyMatch(x -> OreDictionary.getOreName(x).startsWith("ore"))
+        return (p) -> Arrays.stream(OreDictionary.getOreIDs(p)).anyMatch(w -> OreDictionary.getOreName(w).equals("coal"))
+                ||  Arrays.stream(OreDictionary.getOreIDs(p)).anyMatch(x -> OreDictionary.getOreName(x).startsWith("ore"))
                 ||  Arrays.stream(OreDictionary.getOreIDs(p)).anyMatch(y -> OreDictionary.getOreName(y).startsWith("gem"))
                 ||  Arrays.stream(OreDictionary.getOreIDs(p)).anyMatch(z -> OreDictionary.getOreName(z).startsWith("dust"))
                 || tektopiaAddons$isStoneItem().test(p)
                 || super.isHarvestItem().test(p);
     }
 
-    @Inject(method = "entityInit", at = @At("TAIL"), remap = false)
+    @Inject(method = "entityInit", at = @At("TAIL"))
     protected void entityInit(CallbackInfo ci) {
         this.registerAIFilter("mining.stone", MINE_STONE);
     }
 
-    @Inject(method = "initEntityAI", at = @At("TAIL"), remap = false)
+    @Inject(method = "initEntityAI", at = @At("TAIL"))
     protected void initEntityAI(CallbackInfo ci) {
         for(Item item : TektopiaAddons.oreItems)
         {


### PR DESCRIPTION
Modified the list of items miners can harvest to ensure they properly recognize and collect coal items after mining, and added coal items to the "coal" mineral dictionary.
Fixed the registration method for the "mining.stone" filter, ensuring it is now properly registered and functions as intended.