### PR TITLE
Fix farmer beetroot and sugar canes collection

### DIFF
--- a/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
@@ -7,6 +7,7 @@ import com.leviathanstudio.craftstudio.client.util.EnumResourceType;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCrops;
 import net.minecraft.block.BlockOre;
+import net.minecraft.init.Items;
 import net.minecraft.item.*;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Loader;
@@ -121,12 +122,15 @@ public class TektopiaAddons {
 			}
 		}
 
+		OreDictionary.registerOre("cropBeetroot", Items.BEETROOT);
+
 		Random rand = new Random();
         for(Item item : items)
 		{
 			ItemStack stack = new ItemStack(item);
 			if(stack.isEmpty()) continue;
-			if(Arrays.stream(OreDictionary.getOreIDs(stack)).anyMatch(x -> OreDictionary.getOreName(x).startsWith("crop")))
+			if(Arrays.stream(OreDictionary.getOreIDs(stack)).anyMatch(x -> OreDictionary.getOreName(x).startsWith("crop"))
+					||  Arrays.stream(OreDictionary.getOreIDs(stack)).anyMatch(y -> OreDictionary.getOreName(y).equals("sugarcane")))
 			{
 				cropItems.add(item);
 				//LOGGER.info("Found Crop: " + item.getRegistryName());


### PR DESCRIPTION
**Fixes #5**
Modified the list of items farmers can harvest to ensure they properly recognize and collect beetroot and sugarcane items after harvesting, and added beetroot items to the "cropBeetroot" mineral dictionary.