### PR TITLE
Move Monster Hostility Behavior to Village Hardcore Mode Config

### DIFF
--- a/src/main/java/com/sushiy/tektopiaaddons/ConfigHandler.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/ConfigHandler.java
@@ -26,6 +26,7 @@ public class ConfigHandler {
     public static int VILLAGE_RADIUS = 100;
     public static int VILLAGE_ANIMALPEN_SIZE_PERCENTAGE_MULTIPLIER = 100;
     public static boolean NEW_PLAYERS_RECEIVE_STARTERBOOK = false;
+    public static boolean VILLAGE_HARDCORE_MODE_ENABLED = false;
 
     public static void init(File file)
     {
@@ -38,6 +39,7 @@ public class ConfigHandler {
         //VILLAGE_RADIUS = config.getInt("Radius of village ", category, 100, 0, 300, "!!Change with caution!!.default 100");
         VILLAGE_ANIMALPEN_SIZE_PERCENTAGE_MULTIPLIER = Math.round(config.getFloat("Multiplier for animals in a pen", category, 1, 0, 10, "default 1")* 100);
         NEW_PLAYERS_RECEIVE_STARTERBOOK = config.getBoolean("Should new players get a starterbook", category, false, "");
+        VILLAGE_HARDCORE_MODE_ENABLED = config.getBoolean("Enable Village Hardcore Mode", category, false, "More types of monsters will attack villagers");
 
 
         category = "Food";

--- a/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityVillagerTekMixin.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityVillagerTekMixin.java
@@ -1,7 +1,6 @@
 package com.sushiy.tektopiaaddons.mixin;
-import com.leviathanstudio.craftstudio.common.animation.AnimationHandler;
+import com.sushiy.tektopiaaddons.ConfigHandler;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.monster.*;
 import net.minecraft.world.World;
 import net.tangotek.tektopia.entities.EntityNecromancer;
@@ -23,6 +22,7 @@ public abstract class EntityVillagerTekMixin extends EntityVillageNavigator
      */
     @Overwrite(remap = false)
     public com.google.common.base.Predicate<Entity> isHostile() {
-        return (e) -> e.isCreatureType(EnumCreatureType.MONSTER, false) || e instanceof EntityZombie && !(e instanceof EntityPigZombie) || e instanceof EntityWitherSkeleton || e instanceof EntityEvoker || e instanceof EntityVex || e instanceof EntityVindicator || e instanceof EntityNecromancer;
+        return (e) -> ConfigHandler.VILLAGE_HARDCORE_MODE_ENABLED && IMob.VISIBLE_MOB_SELECTOR.apply(e) && !(e instanceof EntityCreeper)
+                || e instanceof EntityZombie && !(e instanceof EntityPigZombie) || e instanceof EntityWitherSkeleton || e instanceof EntityEvoker || e instanceof EntityVex || e instanceof EntityVindicator || e instanceof EntityNecromancer;
     }
 }


### PR DESCRIPTION
Currently, TektopiaAddons treats all entities classified as “monster” as hostile to villages by default, regardless of player preference or modpack design. This change moves that behavior into the Village Hardcore Mode configuration option, allowing players to enable or disable it according to their preferred difficulty.

Additionally, the definition of hostile entities has been updated to match the vanilla Iron Golem’s target list, ensuring consistency with base Minecraft’s logic for protecting villages. This provides players with a more predictable and balanced defense system, especially when integrating other mods that add custom mobs.