### PR TITLE
Fix floating first path node

### DIFF
--- a/src/main/java/com/sushiy/tektopiaaddons/ConfigHandler.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/ConfigHandler.java
@@ -31,7 +31,7 @@ public class ConfigHandler {
     public static boolean VILLAGER_STONE_SUPPORT_ENABLE = false;
 
     public static String[] MONSTER_IGNORE_LIST;
-    public static String[] MONSTER_IGNORE_LIST_DEFAULT = {"Creeper", "Witch", "Enderman"};
+    public static String[] MONSTER_IGNORE_LIST_DEFAULT = {"Witch", "Enderman"};
 
     public static void init(File file)
     {

--- a/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
@@ -30,7 +30,7 @@ import java.util.*;
 )
 public class TektopiaAddons {
 	public static final String MODID = "tektopiaaddons";
-	public static final String NAME = "Tekotpia Addons";
+	public static final String NAME = "Tektopia Addons";
 	public static final String VERSION = "1.4.7";
 	
 	public static final Logger LOGGER = LogManager.getLogger(MODID);

--- a/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/TektopiaAddons.java
@@ -73,7 +73,6 @@ public class TektopiaAddons {
 	@Mod.EventHandler
 	public void preinit(FMLPreInitializationEvent preinit) {
 		ConfigHandler.registerConfig(preinit);
-		OreDictionary.registerOre("cropBeetroot",Items.BEETROOT);
 	}
 
 	@Mod.EventHandler

--- a/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityMinerMixin.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityMinerMixin.java
@@ -104,24 +104,24 @@ public abstract class EntityMinerMixin extends EntityVillagerTek {
     @Inject(method = "buildCraftSet", at = @At("RETURN"), cancellable = true, remap = false)
     private static void buildCraftSetInject(CallbackInfoReturnable<List<Recipe>> cir) {
         if (!ConfigHandler.VILLAGER_STONE_SUPPORT_ENABLE) return;
-        List<Recipe> recipes = new ArrayList();
-        List<ItemStack> ingredients = new ArrayList();
+        List<Recipe> recipes = new ArrayList<>();
+        List<ItemStack> ingredients = new ArrayList<>();
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.COBBLESTONE), 3));
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.LOG), 1, 99));
         Recipe recipe = new Recipe(ProfessionType.MINER, "craft_stone_pickaxe", 2, new ItemStack(Items.STONE_PICKAXE, 1), ingredients, 1, 1, (v) -> v.getSkillLerp(ProfessionType.MINER, 9, 3), 1, (v) -> !hasBetterPick(v));
         recipes.add(recipe);
         recipes.addAll(cir.getReturnValue());
-        ingredients = new ArrayList();
+        ingredients = new ArrayList<>();
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.COBBLESTONE), 3));
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.LOG), 1, 99));
         recipe = new Recipe(ProfessionType.MINER, "craft_stone_axe", 2, new ItemStack(Items.STONE_AXE, 1), ingredients, 1, 1, (v) -> v.getSkillLerp(ProfessionType.MINER, 9, 3), 1, (v) -> hasBetterPick(v));
         recipes.add(recipe);
-        ingredients = new ArrayList();
+        ingredients = new ArrayList<>();
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.COBBLESTONE), 2));
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.LOG), 1, 99));
         recipe = new Recipe(ProfessionType.MINER, "craft_stone_sword", 2, new ItemStack(Items.STONE_SWORD, 1), ingredients, 1, 1, (v) -> v.getSkillLerp(ProfessionType.MINER, 9, 3), 1, (v) -> hasBetterPick(v));
         recipes.add(recipe);
-        ingredients = new ArrayList();
+        ingredients = new ArrayList<>();
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.COBBLESTONE), 2));
         ingredients.add(new ItemStack(Item.getItemFromBlock(Blocks.LOG), 1, 99));
         recipe = new Recipe(ProfessionType.MINER, "craft_stone_hoe", 2, new ItemStack(Items.STONE_HOE, 1), ingredients, 2, 3, (v) -> v.getSkillLerp(ProfessionType.MINER, 9, 3), 1, (v) -> hasBetterPick(v));

--- a/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityVillagerTekMixin.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/mixin/EntityVillagerTekMixin.java
@@ -24,14 +24,14 @@ public abstract class EntityVillagerTekMixin extends EntityVillageNavigator
      */
     @Overwrite(remap = false)
     public com.google.common.base.Predicate<Entity> isHostile() {
-        return (e) -> ConfigHandler.VILLAGE_HARDCORE_MODE_ENABLED && IMob.VISIBLE_MOB_SELECTOR.apply(e) && !(e instanceof EntityCreeper)
-                || e instanceof EntityZombie && !(e instanceof EntityPigZombie) 
-                || e instanceof EntityWitherSkeleton 
-                || e instanceof EntityEvoker 
-                || e instanceof EntityVex 
-                || e instanceof EntityVindicator 
-                || e instanceof EntityNecromancer
-                && !TektopiaAddons.ignoredMonsters.contains(e.getName());
+        return (e) -> !TektopiaAddons.ignoredMonsters.contains(e.getName())
+                && (ConfigHandler.VILLAGE_HARDCORE_MODE_ENABLED && IMob.VISIBLE_MOB_SELECTOR.apply(e) && !(e instanceof EntityCreeper)
+                || e instanceof EntityZombie && !(e instanceof EntityPigZombie)
+                || e instanceof EntityWitherSkeleton
+                || e instanceof EntityEvoker
+                || e instanceof EntityVex
+                || e instanceof EntityVindicator
+                || e instanceof EntityNecromancer);
     }
     /**
      * @author Sushiy

--- a/src/main/java/com/sushiy/tektopiaaddons/mixin/VillageMixin.java
+++ b/src/main/java/com/sushiy/tektopiaaddons/mixin/VillageMixin.java
@@ -1,0 +1,24 @@
+package com.sushiy.tektopiaaddons.mixin;
+
+import net.minecraft.util.math.BlockPos;
+import net.tangotek.tektopia.Village;
+import net.tangotek.tektopia.structures.VillageStructure;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = Village.class)
+public abstract class VillageMixin {
+    @Redirect(
+            method = "addStructure",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/tangotek/tektopia/structures/VillageStructure;getDoorOutside()Lnet/minecraft/util/math/BlockPos;",
+                    ordinal = 0
+            ),
+            remap = false
+    )
+    private BlockPos getDoorOutsideRedirect(VillageStructure struct) {
+        return struct.getDoor();
+    }
+}

--- a/src/main/resources/mixins.tektopiaaddons.json
+++ b/src/main/resources/mixins.tektopiaaddons.json
@@ -19,6 +19,7 @@
     "ModEntititiesMixin",
     "TekVillagerMixin",
     "VillageDataMixin",
+    "VillageMixin",
     "VillageStructureBlacksmithMixin",
     "VillageStructureMerchantStallMixin"
   ],


### PR DESCRIPTION
This fixes an issue where the initial village path node could spawn floating in the air. It was being placed one block in front of the Town Hall door regardless of the terrain. The fix moves its spawn point to the door block itself.